### PR TITLE
fix: Dashboard parent link navigates to /dashboard (#68)

### DIFF
--- a/client/src/components/Layout/Sidebar.tsx
+++ b/client/src/components/Layout/Sidebar.tsx
@@ -93,6 +93,19 @@ export function Sidebar({ isOpen }: SidebarProps) {
     },
   ];
 
+  // Toggle expand/collapse for items with children
+  const handleToggleExpand = useCallback((itemId: string) => {
+    setExpandedItems(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(itemId)) {
+        newSet.delete(itemId);
+      } else {
+        newSet.add(itemId);
+      }
+      return newSet;
+    });
+  }, []);
+
   const handleNavClick = (item: NavItem) => {
     if (item.action) {
       item.action();
@@ -101,17 +114,17 @@ export function Sidebar({ isOpen }: SidebarProps) {
       setActivePage(item.id);
       setCurrentPage('dashboard');
       navigate(PAGE_ROUTES['dashboard']);
+    } else if (item.id === 'dashboard') {
+      // Dashboard parent item - navigate to dashboard AND expand if collapsed
+      setCurrentPage('dashboard');
+      navigate(PAGE_ROUTES['dashboard']);
+      // Auto-expand dashboard children if not already expanded
+      if (!expandedItems.has('dashboard')) {
+        handleToggleExpand('dashboard');
+      }
     } else if (item.children) {
-      // Toggle expansion for items with children
-      setExpandedItems(prev => {
-        const newSet = new Set(prev);
-        if (newSet.has(item.id)) {
-          newSet.delete(item.id);
-        } else {
-          newSet.add(item.id);
-        }
-        return newSet;
-      });
+      // Other items with children - just toggle expansion (Tasks, Manage)
+      handleToggleExpand(item.id);
     } else {
       const pageId = item.id as PageType;
       setCurrentPage(pageId);
@@ -170,10 +183,19 @@ export function Sidebar({ isOpen }: SidebarProps) {
               {item.label}
             </span>
             {hasChildren && (
-              <MuiIcons.ChevronRight
-                style={{ fontSize: 16 }}
-                className={`transition-transform duration-200 text-slate-500 ${isExpanded ? 'rotate-90' : ''}`}
-              />
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleToggleExpand(item.id);
+                }}
+                className="p-0.5 hover:bg-slate-600/50 rounded cursor-pointer"
+                data-testid="nav-chevron"
+              >
+                <MuiIcons.ChevronRight
+                  style={{ fontSize: 16 }}
+                  className={`transition-transform duration-200 text-slate-500 ${isExpanded ? 'rotate-90' : ''}`}
+                />
+              </div>
             )}
           </>
         )}
@@ -274,6 +296,7 @@ export function Sidebar({ isOpen }: SidebarProps) {
 
   return (
     <aside
+      data-testid="sidebar"
       className={`
         fixed left-0 top-16 h-[calc(100vh-4rem)]
         bg-slate-800/90 backdrop-blur-md border-r border-slate-700/50

--- a/client/src/globals.d.ts
+++ b/client/src/globals.d.ts
@@ -1,0 +1,4 @@
+// Global type definitions for Vite defines
+declare const __BUILD_TIME__: string;
+declare const __THEME_VERSION__: string;
+declare const __THEME_PORT__: string;

--- a/tests/issue-68-dashboard-parent-link.spec.ts
+++ b/tests/issue-68-dashboard-parent-link.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Issue #68: Dashboard parent link should navigate to main dashboard page
+ *
+ * Bug: Clicking on "Dashboard" in the sidebar may only expand/collapse children
+ * without navigating to the main dashboard page.
+ *
+ * Success Criteria:
+ * - [ ] Clicking "Dashboard" text navigates to /dashboard
+ * - [ ] Child pages still accessible via their own links
+ * - [ ] Expand/collapse behavior preserved (via chevron or separate control)
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Issue #68: Dashboard parent link navigates to /dashboard', () => {
+
+  test.beforeEach(async ({ page }) => {
+    // Start on a non-dashboard page
+    await page.goto('/manage/habits');
+    await page.waitForSelector('[data-testid="sidebar"]', { timeout: 10000 });
+  });
+
+  test('clicking Dashboard label navigates to /dashboard', async ({ page }) => {
+    // Click on the Dashboard nav item
+    const dashboardNav = page.locator('[data-testid="nav-dashboard"]');
+    await dashboardNav.click();
+
+    // Should navigate to dashboard (root path)
+    await expect(page).toHaveURL('/');
+
+    // Dashboard content should be visible
+    await expect(page.locator('[data-testid="dashboard-page"]')).toBeVisible();
+  });
+
+  test('clicking chevron expands/collapses without navigating', async ({ page }) => {
+    // Find the chevron in the Dashboard nav item
+    const dashboardNav = page.locator('[data-testid="nav-dashboard"]');
+    const chevron = dashboardNav.locator('[data-testid="nav-chevron"]');
+
+    // Get current URL
+    const initialUrl = page.url();
+
+    // Click chevron to toggle
+    await chevron.click();
+
+    // URL should not change
+    await expect(page).toHaveURL(initialUrl);
+
+    // Children should be visible (expanded)
+    const children = page.locator('[data-testid="nav-dashboard-children"]');
+    await expect(children).toBeVisible();
+
+    // Click chevron again to collapse
+    await chevron.click();
+
+    // URL still shouldn't change
+    await expect(page).toHaveURL(initialUrl);
+  });
+
+  test('child pages accessible via their own links', async ({ page }) => {
+    // Expand Dashboard children first
+    const dashboardNav = page.locator('[data-testid="nav-dashboard"]');
+    const chevron = dashboardNav.locator('[data-testid="nav-chevron"]');
+    await chevron.click();
+
+    // Wait for children to be visible
+    await page.waitForSelector('[data-testid="nav-dashboard-children"]');
+
+    // Click first child page
+    const children = page.locator('[data-testid="nav-dashboard-children"] button').first();
+    await children.click();
+
+    // Should navigate to dashboard
+    await expect(page).toHaveURL('/');
+  });
+
+  test('dashboard parent is highlighted when on dashboard page', async ({ page }) => {
+    // Navigate to dashboard
+    await page.goto('/');
+    await page.waitForSelector('[data-testid="dashboard-page"]');
+
+    // Dashboard nav item should have active styling
+    const dashboardNav = page.locator('[data-testid="nav-dashboard"]');
+    await expect(dashboardNav).toHaveClass(/active|bg-teal|selected/);
+  });
+});


### PR DESCRIPTION
## Summary
- Clicking "Dashboard" label now navigates to /dashboard
- Chevron click still toggles expand/collapse (separate handler with stopPropagation)
- Auto-expands Dashboard children when navigating if collapsed
- Added data-testid to sidebar and chevron for testing

## Changes
- `Sidebar.tsx`: Split navigation and expand/collapse logic
- New chevron wrapper with separate click handler
- Dashboard item now navigates on click, not just expand/collapse

## Test plan
- [ ] Click "Dashboard" label → navigates to /
- [ ] Click chevron → toggles expand/collapse without navigation
- [ ] Child pages still navigate correctly
- [ ] Dashboard nav item highlighted when on dashboard page

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)